### PR TITLE
fix(docs): name incorrect in .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "gkehub",
+    "name": "gke-hub",
     "name_pretty": "GKE Hub",
     "product_documentation": "https://cloud.google.com/anthos/gke",
     "client_documentation": "https://googleapis.dev/nodejs/gke-hub/latest/",


### PR DESCRIPTION
Fix up the name of reference docs to match library name.